### PR TITLE
Allow <wml2:metadata> in <wml2:MeasurementTVP>

### DIFF
--- a/R/GetValues.R
+++ b/R/GetValues.R
@@ -295,9 +295,14 @@ GetValues <- function(server, siteCode=NULL, variableCode=NULL, startDate=NULL, 
         xp <- xp[-1]
       }
 
+      # allow for the case where optional <wml2:metadata> appears within <wml2:MeasurementTVP>
+      if(length(xp) > 0){
+        numElements = length(names(xp[[1]]))
+      }
+      
       xp2 <- unlist(xp)
-      xpTimes <- xp2[seq(1, length(xp2), 2)]
-      xpVals <- xp2[seq(2, length(xp2), 2)]
+      xpTimes <- xp2[seq(1, length(xp2), numElements)]
+      xpVals <- xp2[seq(2, length(xp2), numElements)]
 
       DF2 <- data.frame(time=xpTimes, value=xpVals, stringsAsFactors = FALSE)
 


### PR DESCRIPTION
Hi @jirikadlec2 - it has been a while - I hope you are doing well! Here's a small patch for your consideration. 

# Overview
This allows time and value to be parsed when there is a `<wml2:metadata>` within the `<wml2:MeasurementTVP>` element. 

# Details
WaterML 2.0 supports an optional `<wml2:metadata>` element within the `<wml2:MeasurementTVP>` element, but the current implementation assumes only `<wml2:time>` and `<wml2:value>` elements are present. 

Here is the relevant section of the schema for reference:
 ```
 <element name="TimeValuePair" type="wml2:TimeValuePairType"/>
  <complexType name="TimeValuePairType" abstract="true">
    <sequence>
      <element maxOccurs="1" minOccurs="0" name="time" type="gml:TimePositionType">
        <annotation>
          <documentation>The time instant for the data point.</documentation>
        </annotation>
      </element>
    </sequence>
  </complexType>

  <element name="MeasurementTVP" type="wml2:MeasureTVPType" substitutionGroup="wml2:TimeValuePair"/>
  <complexType name="MeasureTVPType">
    <complexContent>
      <extension base="wml2:TimeValuePairType">
        <sequence>
          <element maxOccurs="1" minOccurs="0" name="value" nillable="true" type="wml2:MeasureType">
            <annotation>
              <documentation>The value of a measurement timeseries is a measure</documentation>
            </annotation>
          </element>
          <element maxOccurs="1" minOccurs="0" name="metadata"
            type="wml2:TVPMeasurementMetadataPropertyType"/>
        </sequence>
      </extension>
    </complexContent>
  </complexType>
```
WaterML 2.0.2 schema retrieved from http://schemas.opengis.net/waterml/ 

# Pre-Fix Example When Metadata Element is Present
Here is an example element containing a <wml2:metadata> element retrieved from https://waterservices.usgs.gov/nwis/iv/?format=waterml,2.0&sites=01359139&parameterCd=00010&period=P3D

```
<wml2:MeasurementTVP>
    <wml2:time>2020-12-01T13:30:00-05:00</wml2:time>
    <wml2:value>6.8</wml2:value>
    <wml2:metadata>
        <wml2:TVPMeasurementMetadata/>
    </wml2:metadata>
</wml2:MeasurementTVP>
```
Here is a view of `xp` after a similar set of `<wml2:MeasurementTVP>` were parsed: 
![names inside xp element](https://user-images.githubusercontent.com/5167970/101199059-6246bd80-3632-11eb-910d-9aa927523fcc.png)

The assumption of there only being two sub-elements in `<wml2:MeasurementTVP>` causes an error to be thrown or generates a warning about coercion.

_error case_
![error](https://user-images.githubusercontent.com/5167970/101199428-dda86f00-3632-11eb-8360-1325d40d4474.png)

_warning case_
![warning](https://user-images.githubusercontent.com/5167970/101199492-f6b12000-3632-11eb-86c7-63770706ef40.png)

If coercion succeeds, then the output dataframe is sparse: 
![output after warning](https://user-images.githubusercontent.com/5167970/101199087-696dcb80-3632-11eb-91c9-a8e3614f68d6.png)

# Post-Fix Example When Metadata Element is Present
Running this branch on the previous example throws no errors or warnings: 
![post-fix success](https://user-images.githubusercontent.com/5167970/101199846-75a65880-3633-11eb-9261-bc32f0ff0666.png)

The output dataframe is also regular: 
![post-fix output ](https://user-images.githubusercontent.com/5167970/101199878-835bde00-3633-11eb-87bb-759c4b0807da.png)

# Parsing When Only Time and Value Elements are Present
After the fix, it is still possible to parse when only Time and Value elements are present. 
```
vals <- WaterML::GetValues("http://www.waterml2.org/KiWIS-WML2-Example.wml")
```

![time value only](https://user-images.githubusercontent.com/5167970/101201267-763fee80-3635-11eb-9f00-23f963ba5532.png)



